### PR TITLE
feat: support more typst versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 .forgejo
 pnpm-workspace.yaml
+.playwright/
+.playwright-mcp/

--- a/package.json
+++ b/package.json
@@ -30,6 +30,15 @@
     "typst.ts-0.14": "npm:@myriaddreamin/typst.ts@0.7.0-rc1",
     "typst-ts-renderer-0.14": "npm:@myriaddreamin/typst-ts-renderer@0.7.0-rc1",
     "typst-ts-compiler-0.14": "npm:@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1",
+    "typst.ts-0.14.1": "npm:@myriaddreamin/typst.ts@0.7.0-rc2",
+    "typst-ts-renderer-0.14.1": "npm:@myriaddreamin/typst-ts-renderer@0.7.0-rc2",
+    "typst-ts-compiler-0.14.1": "npm:@myriaddreamin/typst-ts-web-compiler@0.7.0-rc2",
+    "typst.ts-0.14.2": "npm:@myriaddreamin/typst.ts@0.7.0",
+    "typst-ts-renderer-0.14.2": "npm:@myriaddreamin/typst-ts-renderer@0.7.0",
+    "typst-ts-compiler-0.14.2": "npm:@myriaddreamin/typst-ts-web-compiler@0.7.0",
+    "typst.ts-0.15.0": "npm:@myriaddreamin/typst.ts@0.8.0-rc1",
+    "typst-ts-renderer-0.15.0": "npm:@myriaddreamin/typst-ts-renderer@0.8.0-rc1",
+    "typst-ts-compiler-0.15.0": "npm:@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1",
     "isomorphic-git": "^1.33.1",
     "vanjs-core": "^1.5.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,18 +20,45 @@ importers:
       typst-ts-compiler-0.14:
         specifier: npm:@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1
         version: '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1'
+      typst-ts-compiler-0.14.1:
+        specifier: npm:@myriaddreamin/typst-ts-web-compiler@0.7.0-rc2
+        version: '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc2'
+      typst-ts-compiler-0.14.2:
+        specifier: npm:@myriaddreamin/typst-ts-web-compiler@0.7.0
+        version: '@myriaddreamin/typst-ts-web-compiler@0.7.0'
+      typst-ts-compiler-0.15.0:
+        specifier: npm:@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1
+        version: '@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1'
       typst-ts-renderer-0.13:
         specifier: npm:@myriaddreamin/typst-ts-renderer@0.6.1-rc5
         version: '@myriaddreamin/typst-ts-renderer@0.6.1-rc5'
       typst-ts-renderer-0.14:
         specifier: npm:@myriaddreamin/typst-ts-renderer@0.7.0-rc1
         version: '@myriaddreamin/typst-ts-renderer@0.7.0-rc1'
+      typst-ts-renderer-0.14.1:
+        specifier: npm:@myriaddreamin/typst-ts-renderer@0.7.0-rc2
+        version: '@myriaddreamin/typst-ts-renderer@0.7.0-rc2'
+      typst-ts-renderer-0.14.2:
+        specifier: npm:@myriaddreamin/typst-ts-renderer@0.7.0
+        version: '@myriaddreamin/typst-ts-renderer@0.7.0'
+      typst-ts-renderer-0.15.0:
+        specifier: npm:@myriaddreamin/typst-ts-renderer@0.8.0-rc1
+        version: '@myriaddreamin/typst-ts-renderer@0.8.0-rc1'
       typst.ts-0.13:
         specifier: npm:@myriaddreamin/typst.ts@0.6.1-rc5
-        version: '@myriaddreamin/typst.ts@0.6.1-rc5(@myriaddreamin/typst-ts-renderer@0.7.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1)'
+        version: '@myriaddreamin/typst.ts@0.6.1-rc5(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)'
       typst.ts-0.14:
         specifier: npm:@myriaddreamin/typst.ts@0.7.0-rc1
-        version: '@myriaddreamin/typst.ts@0.7.0-rc1(@myriaddreamin/typst-ts-renderer@0.7.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1)'
+        version: '@myriaddreamin/typst.ts@0.7.0-rc1(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)'
+      typst.ts-0.14.1:
+        specifier: npm:@myriaddreamin/typst.ts@0.7.0-rc2
+        version: '@myriaddreamin/typst.ts@0.7.0-rc2(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)'
+      typst.ts-0.14.2:
+        specifier: npm:@myriaddreamin/typst.ts@0.7.0
+        version: '@myriaddreamin/typst.ts@0.7.0(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)'
+      typst.ts-0.15.0:
+        specifier: npm:@myriaddreamin/typst.ts@0.8.0-rc1
+        version: '@myriaddreamin/typst.ts@0.8.0-rc1(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)'
       vanjs-core:
         specifier: ^1.5.5
         version: 1.5.5
@@ -223,14 +250,32 @@ packages:
   '@myriaddreamin/typst-ts-renderer@0.6.1-rc5':
     resolution: {integrity: sha512-GOfB3H2o5CW0sKwuS8nojf6G1pasc6N8zCsD84MPdhBdGA8bCFDtZrAeJ2QsQID0qyiXjpWbYjh+PGzCvgDa1g==}
 
+  '@myriaddreamin/typst-ts-renderer@0.7.0':
+    resolution: {integrity: sha512-3sXIGxZn9MufPrPn6251DeuLf2FIEILYNzY5lX0XOJmaIYqgvQ3qpfqkCjgQD+splBvt5R1N3BuuNFrZKsHhMw==}
+
   '@myriaddreamin/typst-ts-renderer@0.7.0-rc1':
     resolution: {integrity: sha512-Dd0xP0THKiUwYVTX+2FW4gzBl4i3BNWLAO/ZAReSCkbaPiFb6py5heSvXX0vtH8sXsFQOB3qhxz68sEcq9oRKg==}
+
+  '@myriaddreamin/typst-ts-renderer@0.7.0-rc2':
+    resolution: {integrity: sha512-god1tcb2YJDkQfA8gLGcAmykVGBpNKorqqDkXVy3InC18KRbsverJhlrHoONurNIU9JuIHoWjJ2D1ntpjPgzbA==}
+
+  '@myriaddreamin/typst-ts-renderer@0.8.0-rc1':
+    resolution: {integrity: sha512-SEU4JTozt3paUnuJolTkWQk9s/dO1hkaNHXGsfMONcV9VY+Dyt/ypESvaPezAwhKsH0FvPpdOmw2djKlVW/Osw==}
 
   '@myriaddreamin/typst-ts-web-compiler@0.6.1-rc5':
     resolution: {integrity: sha512-jQDBIw3RAHcB40YQYGgaPkzjbCiFcElkFR9u6yHWBGwZo2TNz/xtHspJ82IeSxtisjeA25azEJCbl254Aq2HGg==}
 
+  '@myriaddreamin/typst-ts-web-compiler@0.7.0':
+    resolution: {integrity: sha512-nMwMcfOBy5pABPDuVM7/u8425SxhPUM+OJe6daqqgVOT3+neCTz4JKwx2L8XasfEHTNvd0cUI07LR9q5ADo7Gw==}
+
   '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1':
     resolution: {integrity: sha512-ICSdiR6U0GH1wqDKRYpvVWV9TBmA0kD0IPQwl0f2BhlHj4qrOPtC5GfSXGxzRiGNUou/Mhr9V8f2wgzBIp4P4Q==}
+
+  '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc2':
+    resolution: {integrity: sha512-WFO/ecKUfeclld5uDxyjgpnIafKpp2LrS6T1vY+CHaSxCm099AneAQIYFg+OtX+NbFpJsLGCBFSw/qppJJmBAw==}
+
+  '@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1':
+    resolution: {integrity: sha512-Uf62Uh1Oo0r/9XnIt87SaSTe7lWho2Eyse6/d6QGz0SUzDd5DJRedVriz+yY8dBPK8QzCcxMLDsZgo7z9ACqAg==}
 
   '@myriaddreamin/typst.ts@0.6.1-rc5':
     resolution: {integrity: sha512-FuVMuBTdfFZfIHLVShZ30qEdqzVGKM26k62OVC5UhoB2DSMi6D4o5tIgoCY4PzYcT8/dRgHcbmqA4Ep96VFvAQ==}
@@ -243,11 +288,44 @@ packages:
       '@myriaddreamin/typst-ts-web-compiler':
         optional: true
 
+  '@myriaddreamin/typst.ts@0.7.0':
+    resolution: {integrity: sha512-JtO5Td/1QesH1IBKAZtbayFNK8u2sl3iz18Y67uYqBEdcXiu3z+wpZcDDKlmVJvAcCgSjHTnuk6ZLfkYclrGGQ==}
+    peerDependencies:
+      '@myriaddreamin/typst-ts-renderer': ^0.7.0
+      '@myriaddreamin/typst-ts-web-compiler': ^0.7.0
+    peerDependenciesMeta:
+      '@myriaddreamin/typst-ts-renderer':
+        optional: true
+      '@myriaddreamin/typst-ts-web-compiler':
+        optional: true
+
   '@myriaddreamin/typst.ts@0.7.0-rc1':
     resolution: {integrity: sha512-IZ78l1iLTMM61pf1SmqtojkgM2aloQVSzlNvStKtYu+qleOEzh/ph7zTNmfM8j5vlflCkos85E+UKQvLdC9C7Q==}
     peerDependencies:
       '@myriaddreamin/typst-ts-renderer': ^0.7.0-rc1
       '@myriaddreamin/typst-ts-web-compiler': ^0.7.0-rc1
+    peerDependenciesMeta:
+      '@myriaddreamin/typst-ts-renderer':
+        optional: true
+      '@myriaddreamin/typst-ts-web-compiler':
+        optional: true
+
+  '@myriaddreamin/typst.ts@0.7.0-rc2':
+    resolution: {integrity: sha512-VM8JqsRcL3AEJ5cuPBn/YvnGTXK/BRPlxdGB2bR48Of/8OIGaPiunv2QfZBIMBBrtbTygUOtAY9BZvkS1AFqgA==}
+    peerDependencies:
+      '@myriaddreamin/typst-ts-renderer': ^0.7.0-rc2
+      '@myriaddreamin/typst-ts-web-compiler': ^0.7.0-rc2
+    peerDependenciesMeta:
+      '@myriaddreamin/typst-ts-renderer':
+        optional: true
+      '@myriaddreamin/typst-ts-web-compiler':
+        optional: true
+
+  '@myriaddreamin/typst.ts@0.8.0-rc1':
+    resolution: {integrity: sha512-preiApbD/bwtksehJ7kqUuM9QZfKKQYcv/3dX5gTZiaQgvzfZ7kZXg0PJIM7dJIbnk6NW4bZo83+s3+m+XP5SQ==}
+    peerDependencies:
+      '@myriaddreamin/typst-ts-renderer': ^0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': ^0.8.0-rc1
     peerDependenciesMeta:
       '@myriaddreamin/typst-ts-renderer':
         optional: true
@@ -997,25 +1075,58 @@ snapshots:
 
   '@myriaddreamin/typst-ts-renderer@0.6.1-rc5': {}
 
+  '@myriaddreamin/typst-ts-renderer@0.7.0': {}
+
   '@myriaddreamin/typst-ts-renderer@0.7.0-rc1': {}
+
+  '@myriaddreamin/typst-ts-renderer@0.7.0-rc2': {}
+
+  '@myriaddreamin/typst-ts-renderer@0.8.0-rc1': {}
 
   '@myriaddreamin/typst-ts-web-compiler@0.6.1-rc5': {}
 
+  '@myriaddreamin/typst-ts-web-compiler@0.7.0': {}
+
   '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1': {}
 
-  '@myriaddreamin/typst.ts@0.6.1-rc5(@myriaddreamin/typst-ts-renderer@0.7.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1)':
-    dependencies:
-      idb: 7.1.1
-    optionalDependencies:
-      '@myriaddreamin/typst-ts-renderer': 0.7.0-rc1
-      '@myriaddreamin/typst-ts-web-compiler': 0.7.0-rc1
+  '@myriaddreamin/typst-ts-web-compiler@0.7.0-rc2': {}
 
-  '@myriaddreamin/typst.ts@0.7.0-rc1(@myriaddreamin/typst-ts-renderer@0.7.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.7.0-rc1)':
+  '@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1': {}
+
+  '@myriaddreamin/typst.ts@0.6.1-rc5(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)':
     dependencies:
       idb: 7.1.1
     optionalDependencies:
-      '@myriaddreamin/typst-ts-renderer': 0.7.0-rc1
-      '@myriaddreamin/typst-ts-web-compiler': 0.7.0-rc1
+      '@myriaddreamin/typst-ts-renderer': 0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': 0.8.0-rc1
+
+  '@myriaddreamin/typst.ts@0.7.0(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)':
+    dependencies:
+      idb: 7.1.1
+    optionalDependencies:
+      '@myriaddreamin/typst-ts-renderer': 0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': 0.8.0-rc1
+
+  '@myriaddreamin/typst.ts@0.7.0-rc1(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)':
+    dependencies:
+      idb: 7.1.1
+    optionalDependencies:
+      '@myriaddreamin/typst-ts-renderer': 0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': 0.8.0-rc1
+
+  '@myriaddreamin/typst.ts@0.7.0-rc2(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)':
+    dependencies:
+      idb: 7.1.1
+    optionalDependencies:
+      '@myriaddreamin/typst-ts-renderer': 0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': 0.8.0-rc1
+
+  '@myriaddreamin/typst.ts@0.8.0-rc1(@myriaddreamin/typst-ts-renderer@0.8.0-rc1)(@myriaddreamin/typst-ts-web-compiler@0.8.0-rc1)':
+    dependencies:
+      idb: 7.1.1
+    optionalDependencies:
+      '@myriaddreamin/typst-ts-renderer': 0.8.0-rc1
+      '@myriaddreamin/typst-ts-web-compiler': 0.8.0-rc1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/src/args.ts
+++ b/src/args.ts
@@ -4,6 +4,7 @@ import {
   storageSpecFromPath,
 } from "./storage";
 import { README, README_CN } from "./storage";
+import { DEFAULT_TYPST_VERSION } from "./typst-version";
 
 // @ts-ignore
 const isDev = false; // import.meta.env !== undefined;
@@ -19,7 +20,7 @@ const TEST_PATH = "@any/github.com/Myriad-Dreamin/gistd/raw/main/README.typ";
 const DEFAULT_PAGE = "1";
 // const DEFAULT_MODE = "doc";
 const DEFAULT_MODE = isDev ? DEFAULT_DEV_MODE : "doc";
-const DEFAULT_VERSION = "latest";
+const DEFAULT_VERSION = DEFAULT_TYPST_VERSION;
 
 export interface Args {
   storage: StorageSpecExt;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,6 +2,7 @@ interface Window {
   $typst: import("@myriaddreamin/typst.ts/contrib/snippet").TypstSnippet;
   $typst$script: any;
   $typst$createRenderer(): Promise<any>;
+  $typstVersion: import("./typst-version").TypstVersionConfig;
   typstLoadFontSync(font: any): Uint8Array;
   initTypstSvg: any;
   handleTypstLocation: any;

--- a/src/loader.bundle.ts
+++ b/src/loader.bundle.ts
@@ -1,4 +1,9 @@
 import { argsFromUrl } from "./args";
+import {
+  resolveTypstVersion,
+  TypstRuntimeId,
+  TypstVersionConfig,
+} from "./typst-version";
 // @ts-ignore
 import renderer013 from "typst-ts-renderer-0.13/wasm?url";
 // @ts-ignore
@@ -7,11 +12,22 @@ import compiler013 from "typst-ts-compiler-0.13/wasm?url";
 import renderer014 from "typst-ts-renderer-0.14/wasm?url";
 // @ts-ignore
 import compiler014 from "typst-ts-compiler-0.14/wasm?url";
+// @ts-ignore
+import renderer0141 from "typst-ts-renderer-0.14.1/wasm?url";
+// @ts-ignore
+import compiler0141 from "typst-ts-compiler-0.14.1/wasm?url";
+// @ts-ignore
+import renderer0142 from "typst-ts-renderer-0.14.2/wasm?url";
+// @ts-ignore
+import compiler0142 from "typst-ts-compiler-0.14.2/wasm?url";
+// @ts-ignore
+import renderer015 from "typst-ts-renderer-0.15.0/wasm?url";
+// @ts-ignore
+import compiler015 from "typst-ts-compiler-0.15.0/wasm?url";
 
-const getConfig = async (v: string) => {
-  switch (v) {
-    case "v0.13.0":
-    case "v0.13.1": {
+const getRuntimeConfig = async (runtime: TypstRuntimeId) => {
+  switch (runtime) {
+    case "0.13": {
       const ts = import("typst.ts-0.13");
       const optionInit = import("typst.ts-0.13/options.init");
       const compilerWrapper = import("typst-ts-compiler-0.13");
@@ -29,11 +45,9 @@ const getConfig = async (v: string) => {
         rendererModule,
       };
     }
-    case "v0.14.0":
-    case "latest":
-    case undefined: {
-      const ts = import("typst.ts-0.14");
-      const optionInit = import("typst.ts-0.14/options.init");
+    case "0.14.0": {
+      const ts = import("typst.ts-0.14.1");
+      const optionInit = import("typst.ts-0.14.1/options.init");
       const compilerWrapper = import("typst-ts-compiler-0.14");
       const rendererWrapper = import("typst-ts-renderer-0.14");
       const compilerModule = fetch(compiler014);
@@ -49,36 +63,92 @@ const getConfig = async (v: string) => {
         rendererModule,
       };
     }
+    case "0.14.1": {
+      const ts = import("typst.ts-0.14.1");
+      const optionInit = import("typst.ts-0.14.1/options.init");
+      const compilerWrapper = import("typst-ts-compiler-0.14.1");
+      const rendererWrapper = import("typst-ts-renderer-0.14.1");
+      const compilerModule = fetch(compiler0141);
+      const rendererModule = fetch(renderer0141);
+
+      return {
+        $typst: (await ts).$typst,
+        disableDefaultFontAssets: (await optionInit).disableDefaultFontAssets,
+        renderer_build_info: (await rendererWrapper).renderer_build_info,
+        compilerWrapper,
+        rendererWrapper,
+        compilerModule,
+        rendererModule,
+      };
+    }
+    case "0.14.2": {
+      const ts = import("typst.ts-0.14.2");
+      const optionInit = import("typst.ts-0.14.2/options.init");
+      const compilerWrapper = import("typst-ts-compiler-0.14.2");
+      const rendererWrapper = import("typst-ts-renderer-0.14.2");
+      const compilerModule = fetch(compiler0142);
+      const rendererModule = fetch(renderer0142);
+
+      return {
+        $typst: (await ts).$typst,
+        disableDefaultFontAssets: (await optionInit).disableDefaultFontAssets,
+        renderer_build_info: (await rendererWrapper).renderer_build_info,
+        compilerWrapper,
+        rendererWrapper,
+        compilerModule,
+        rendererModule,
+      };
+    }
+    case "0.15.0": {
+      const ts = import("typst.ts-0.15.0");
+      const optionInit = import("typst.ts-0.15.0/options.init");
+      const compilerWrapper = import("typst-ts-compiler-0.15.0");
+      const rendererWrapper = import("typst-ts-renderer-0.15.0");
+      const compilerModule = fetch(compiler015);
+      const rendererModule = fetch(renderer015);
+
+      return {
+        $typst: (await ts).$typst,
+        disableDefaultFontAssets: (await optionInit).disableDefaultFontAssets,
+        renderer_build_info: (await rendererWrapper).renderer_build_info,
+        compilerWrapper,
+        rendererWrapper,
+        compilerModule,
+        rendererModule,
+      };
+    }
 
     default: {
-      throw new Error(
-        `invalid version: ${v}, expected "v0.13.0", "v0.13.1", "v0.14.0", or "latest"`
-      );
+      throw new Error(`invalid runtime: ${runtime}`);
     }
   }
 };
 
 (() => {
   const args = argsFromUrl();
-  window.$typst$script = new Promise(async (resolve) => {
-    const tsConfig = await getConfig(args.version);
-    // todo: remove me
-    // @ts-ignore
-    window.$typst = tsConfig.$typst;
-    const $typst = window.$typst;
-    $typst.setCompilerInitOptions({
-      beforeBuild: [tsConfig.disableDefaultFontAssets()],
-      getWrapper: () => tsConfig.compilerWrapper,
-      getModule: () => tsConfig.compilerModule,
-    });
-    $typst.setRendererInitOptions({
-      getWrapper: () => tsConfig.rendererWrapper,
-      getModule: () => tsConfig.rendererModule,
-    });
-    $typst.getRenderer().then(() => {
-      console.log("renderer:", tsConfig.renderer_build_info());
-    });
-    resolve(undefined);
+  window.$typst$script = new Promise((resolve, reject) => {
+    (async () => {
+      const versionConfig: TypstVersionConfig = resolveTypstVersion(args.version);
+      const tsConfig = await getRuntimeConfig(versionConfig.runtime);
+      // todo: remove me
+      // @ts-ignore
+      window.$typst = tsConfig.$typst;
+      window.$typstVersion = versionConfig;
+      const $typst = window.$typst;
+      $typst.setCompilerInitOptions({
+        beforeBuild: [tsConfig.disableDefaultFontAssets()],
+        getWrapper: () => tsConfig.compilerWrapper,
+        getModule: () => tsConfig.compilerModule,
+      });
+      $typst.setRendererInitOptions({
+        getWrapper: () => tsConfig.rendererWrapper,
+        getModule: () => tsConfig.rendererModule,
+      });
+      $typst.getRenderer().then(() => {
+        console.log("renderer:", tsConfig.renderer_build_info());
+      });
+      resolve(undefined);
+    })().catch(reject);
   });
   window.typstBindSemantics = function () {};
   window.typstBindSvgDom = function () {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,8 @@ import { TypstDocument, Doc } from "./doc";
 import { argsFromUrl } from "./args";
 import { getFontProvider } from "./font";
 import { ErrorPanel, DiagnosticMessage } from "./error";
-import type { TypstCompiler } from "typst.ts-0.14";
+import { compileTypstDocument } from "./typst-compiler";
+import { resolveTypstVersion } from "./typst-version";
 
 let $typst = window.$typst;
 
@@ -33,16 +34,7 @@ const PermalinkButton = () =>
       const search = new URLSearchParams(window.location.search || "");
       search.set(
         "g-version",
-        (() => {
-          switch (args.version) {
-            case "v0.13.0":
-            case "v0.13.1":
-            case "v0.14.0":
-              return args.version;
-            default:
-              return "v0.14.0";
-          }
-        })()
+        resolveTypstVersion(args.version).concreteVersion
       );
       window.location.search = search.toString();
     },
@@ -227,92 +219,36 @@ const App = () => {
 
         setTypstTheme(darkMode.val);
 
-        const compiler = await $typst.getCompiler();
-
         console.log("start compile", mainFilePath);
 
-        if ("runWithWorld" in compiler) {
-          await compiler.reset();
-          // todo: remove me
-          // @ts-ignore
-          await compiler.runWithWorld({ mainFilePath }, async (world) => {
-            const { hasError, diagnostics } = (await world.compile()) as {
-              hasError?: boolean;
-              diagnostics: DiagnosticMessage[];
-            };
+        const compileResult = await compileTypstDocument($typst, {
+          mainFilePath,
+          queryPdfpc: mode === "slide",
+        });
+        console.log("diagnostics", compileResult.diagnostics);
+        if (compileResult.hasError) {
+          error.val = compileResult.diagnostics || [];
+          return;
+        }
 
-            console.log("diagnostics", diagnostics);
-            if (
-              (hasError === undefined &&
-                diagnostics &&
-                diagnostics.length > 0) ||
-              hasError
-            ) {
-              error.val = diagnostics || [];
-              return;
-            }
+        if (compileResult.vector !== undefined) {
+          typstDoc.val?.addChangement([
+            compileResult.changeKind,
+            compileResult.vector,
+          ]);
+        }
+        error.val = "";
 
-            const { result: data, diagnostics: diagnostics2 } =
-              await world.vector();
-            if (diagnostics2 && diagnostics2.length > 0) {
-              error.val = diagnostics2;
-              return;
-            }
-            typstDoc.val?.addChangement(["new", data]);
-            error.val = "";
+        if (compileResult.title) {
+          document.title = compileResult.title;
+        }
 
-            if ("title" in world) {
-              const title = world.title();
-              if (title) {
-                document.title = title;
-              }
-            }
-
-            // support pdfpc
-            if (mode === "slide") {
-              try {
-                const pdfpcData = await world.query({
-                  selector: "<pdfpc>",
-                });
-                const processedPdfpc = processPdfpc(pdfpcData);
-                pdfpc.val = processedPdfpc;
-                // Initialize label indices when new pdfpc data is loaded
-                initializeLabelIndices();
-                console.log("processed pdfpc", processedPdfpc);
-              } catch (e) {
-                console.log("this slide does not have pdfpc");
-              }
-            }
-          });
-        } else {
-          let compilerCompat = compiler as any as TypstCompiler;
-          const { result: data, diagnostics } = await compilerCompat.compile({
-            mainFilePath,
-            diagnostics: "full",
-          });
-          console.log("diagnostics", diagnostics);
-          if (diagnostics && diagnostics.length > 0) {
-            error.val = diagnostics;
-            return;
-          }
-
-          if (mode === "slide") {
-            try {
-              const pdfpcData = await compilerCompat.query({
-                mainFilePath,
-                selector: "<pdfpc>",
-              });
-              pdfpc.val = processPdfpc(pdfpcData);
-              // Initialize label indices when new pdfpc data is loaded
-              initializeLabelIndices();
-              console.log("processed pdfpc", pdfpc.val);
-            } catch (e) {
-              console.log("this slide does not have pdfpc");
-            }
-          }
-
-          typstDoc.val.addChangement(["diff-v1", data]);
-          error.val = "";
+        if (mode === "slide" && compileResult.pdfpc !== undefined) {
+          const processedPdfpc = processPdfpc(compileResult.pdfpc);
+          pdfpc.val = processedPdfpc;
+          // Initialize label indices when new pdfpc data is loaded
+          initializeLabelIndices();
+          console.log("processed pdfpc", processedPdfpc);
         }
       }
     } catch (e) {

--- a/src/typst-compiler.ts
+++ b/src/typst-compiler.ts
@@ -1,0 +1,137 @@
+import type { DiagnosticMessage } from "./error";
+
+type ChangeKind = "new" | "diff-v1";
+
+export interface TypstCompileResult {
+  changeKind: ChangeKind;
+  diagnostics: DiagnosticMessage[];
+  hasError: boolean;
+  pdfpc?: unknown;
+  title?: string;
+  vector?: unknown;
+}
+
+export interface CompileTypstOptions {
+  mainFilePath: string;
+  queryPdfpc: boolean;
+}
+
+export async function compileTypstDocument(
+  $typst: any,
+  { mainFilePath, queryPdfpc }: CompileTypstOptions
+): Promise<TypstCompileResult> {
+  const compiler = await $typst.getCompiler();
+
+  if ("runWithWorld" in compiler) {
+    return compileWithWorldCompiler(compiler, { mainFilePath, queryPdfpc });
+  }
+
+  return compileWithLegacyCompiler(compiler, { mainFilePath, queryPdfpc });
+}
+
+async function compileWithWorldCompiler(
+  compiler: any,
+  { mainFilePath, queryPdfpc }: CompileTypstOptions
+): Promise<TypstCompileResult> {
+  await compiler.reset();
+
+  let result: TypstCompileResult | undefined;
+  await compiler.runWithWorld({ mainFilePath }, async (world: any) => {
+    const compileResult = (await world.compile()) as {
+      hasError?: boolean;
+      diagnostics?: DiagnosticMessage[];
+    };
+    const diagnostics = compileResult.diagnostics || [];
+    const hasError =
+      compileResult.hasError ||
+      (compileResult.hasError === undefined && diagnostics.length > 0);
+
+    if (hasError) {
+      result = {
+        changeKind: "new",
+        diagnostics,
+        hasError: true,
+      };
+      return;
+    }
+
+    const vectorResult = (await world.vector()) as {
+      result: unknown;
+      diagnostics?: DiagnosticMessage[];
+    };
+    const vectorDiagnostics = vectorResult.diagnostics || [];
+    if (vectorDiagnostics.length > 0) {
+      result = {
+        changeKind: "new",
+        diagnostics: vectorDiagnostics,
+        hasError: true,
+      };
+      return;
+    }
+
+    result = {
+      changeKind: "new",
+      diagnostics: [],
+      hasError: false,
+      pdfpc: queryPdfpc ? await queryPdfpcInWorld(world) : undefined,
+      title: typeof world.title === "function" ? world.title() : undefined,
+      vector: vectorResult.result,
+    };
+  });
+
+  if (!result) {
+    throw new Error("compiler finished without a result");
+  }
+  return result;
+}
+
+async function compileWithLegacyCompiler(
+  compiler: any,
+  { mainFilePath, queryPdfpc }: CompileTypstOptions
+): Promise<TypstCompileResult> {
+  const { result: vector, diagnostics = [] } = await compiler.compile({
+    mainFilePath,
+    diagnostics: "full",
+  });
+
+  if (diagnostics.length > 0) {
+    return {
+      changeKind: "diff-v1",
+      diagnostics,
+      hasError: true,
+    };
+  }
+
+  return {
+    changeKind: "diff-v1",
+    diagnostics: [],
+    hasError: false,
+    pdfpc: queryPdfpc
+      ? await queryPdfpcInLegacyCompiler(compiler, mainFilePath)
+      : undefined,
+    vector,
+  };
+}
+
+async function queryPdfpcInWorld(world: any) {
+  try {
+    return await world.query({
+      selector: "<pdfpc>",
+    });
+  } catch (e) {
+    console.log("this slide does not have pdfpc");
+    return undefined;
+  }
+}
+
+async function queryPdfpcInLegacyCompiler(compiler: any, mainFilePath: string) {
+  try {
+    return await compiler.query({
+      mainFilePath,
+      selector: "<pdfpc>",
+    });
+  } catch (e) {
+    console.log("this slide does not have pdfpc");
+    return undefined;
+  }
+}

--- a/src/typst-version.ts
+++ b/src/typst-version.ts
@@ -1,0 +1,84 @@
+export type ConcreteTypstVersion =
+  | "v0.13.0"
+  | "v0.13.1"
+  | "v0.14.0"
+  | "v0.14.1"
+  | "v0.14.2"
+  | "v0.15.0";
+
+export type RequestedTypstVersion = ConcreteTypstVersion | "latest";
+
+export type TypstRuntimeId =
+  | "0.13"
+  | "0.14.0"
+  | "0.14.1"
+  | "0.14.2"
+  | "0.15.0";
+
+export interface TypstVersionConfig {
+  concreteVersion: ConcreteTypstVersion;
+  requestedVersion: RequestedTypstVersion;
+  runtime: TypstRuntimeId;
+}
+
+export const DEFAULT_TYPST_VERSION: RequestedTypstVersion = "latest";
+export const LATEST_TYPST_VERSION: ConcreteTypstVersion = "v0.15.0";
+
+const VERSION_CONFIGS: Record<RequestedTypstVersion, TypstVersionConfig> = {
+  "v0.13.0": {
+    concreteVersion: "v0.13.0",
+    requestedVersion: "v0.13.0",
+    runtime: "0.13",
+  },
+  "v0.13.1": {
+    concreteVersion: "v0.13.1",
+    requestedVersion: "v0.13.1",
+    runtime: "0.13",
+  },
+  "v0.14.0": {
+    concreteVersion: "v0.14.0",
+    requestedVersion: "v0.14.0",
+    runtime: "0.14.0",
+  },
+  "v0.14.1": {
+    concreteVersion: "v0.14.1",
+    requestedVersion: "v0.14.1",
+    runtime: "0.14.1",
+  },
+  "v0.14.2": {
+    concreteVersion: "v0.14.2",
+    requestedVersion: "v0.14.2",
+    runtime: "0.14.2",
+  },
+  "v0.15.0": {
+    concreteVersion: "v0.15.0",
+    requestedVersion: "v0.15.0",
+    runtime: "0.15.0",
+  },
+  latest: {
+    concreteVersion: LATEST_TYPST_VERSION,
+    requestedVersion: "latest",
+    runtime: "0.15.0",
+  },
+};
+
+export const SUPPORTED_TYPST_VERSIONS = Object.keys(
+  VERSION_CONFIGS
+) as RequestedTypstVersion[];
+
+export function supportedTypstVersionLabel() {
+  return SUPPORTED_TYPST_VERSIONS.map((v) => `"${v}"`).join(", ");
+}
+
+export function resolveTypstVersion(
+  version: string | undefined
+): TypstVersionConfig {
+  const requested = version || DEFAULT_TYPST_VERSION;
+  if (Object.prototype.hasOwnProperty.call(VERSION_CONFIGS, requested)) {
+    return VERSION_CONFIGS[requested as RequestedTypstVersion];
+  }
+
+  throw new Error(
+    `invalid version: ${requested}, expected ${supportedTypstVersionLabel()}`
+  );
+}


### PR DESCRIPTION
Add explicit Typst version resolution and expand the supported runtime matrix to include v0.14.1, v0.14.2, and v0.15.0.

Also refactor compiler setup into a shared helper so both world-based and legacy compilers use the same compile flow, including PDFPC queries and title handling.

Other changes:
- Set the default Typst version from shared version config
- Expose the resolved Typst version on `window`
- Update permalink generation to preserve the concrete selected version
- Ignore Playwright local artifacts in git
- Refresh lockfile for the new package aliases